### PR TITLE
Fix Docker build with updated JDK package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine:3.20 AS base
 
 # Add OpenJDK17
-RUN apk add --no-cache openjdk17=17.0.12_p7-r0
+RUN apk add --no-cache openjdk17
 
 # Uses /kepler directory
 WORKDIR /kepler
@@ -51,3 +51,4 @@ FROM base AS production
 COPY --from=build /kepler/build ./
 
 CMD [ "sh", "run.sh" ]
+


### PR DESCRIPTION
## Summary
- update Dockerfile to install the current openjdk17 package
- ensure newline at end of Dockerfile

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686370a2e46883328f1f3ca445f1870f