### PR TITLE
Add automatic DB import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,14 @@ FROM base AS production
 # Copy builded Kepler server
 COPY --from=build /kepler/build ./
 
-CMD [ "sh", "run.sh" ]
+# Default ports (can be overridden by environment variables)
+ENV SERVER_PORT=12321 \
+    RCON_PORT=12309 \
+    MUS_PORT=12322
+
+# Expose ports for the emulator, RCON and MUS servers
+EXPOSE ${SERVER_PORT} ${RCON_PORT} ${MUS_PORT}
+
+COPY start.sh ./
+ENTRYPOINT ["sh", "start.sh"]
 

--- a/README.md
+++ b/README.md
@@ -86,19 +86,55 @@ _Don't change `MYSQL_HOST` except if you change the name of the service `mariadb
 
 _You neither should change `MYSQL_PORT`._
 
-### 3. Start Kepler
+### 3. Inicio de Kepler
 
-You just need to run Docker compose inside of Kepler directory :
-
-```shell
-docker compose up -d
-```
-
-To stop Kepler :
+Si prefieres utilizar **Docker** directamente (por ejemplo en EasyPanel) sin
+`docker compose`, primero construye la imagen:
 
 ```shell
-docker compose down
+docker build -t kepler .
 ```
+
+Inicia un contenedor de MariaDB (puedes hacerlo también desde EasyPanel):
+
+```shell
+docker run -d --name kepler-db \
+  -e MARIADB_ROOT_PASSWORD=veryverysecret \
+  -e MYSQL_DATABASE=kepler \
+  -e MYSQL_USER=kepler \
+  -e MYSQL_PASSWORD=verysecret \
+  mariadb:11.4
+```
+
+Por último arranca Kepler enlazándolo con la base de datos y exponiendo los
+puertos necesarios:
+
+```shell
+docker run -d --name kepler --link kepler-db:mariadb \
+  -p 12321:12321 -p 12309:12309 -p 12322:12322 \
+  -e MYSQL_HOSTNAME=mariadb \
+  kepler
+```
+
+Con EasyPanel puedes crear estos contenedores desde su interfaz gráfica y
+configurar las variables de entorno anteriores. Para simplificar aún más el
+proceso, este repositorio incluye un script `deploy.sh` que ejecuta todos los
+pasos anteriores de forma automática:
+
+```shell
+./deploy.sh
+```
+
+El script construye la imagen, inicia MariaDB si no existe, importa
+automáticamente `tools/kepler.sql` la primera vez y arranca Kepler ligado a
+dicha base de datos.
+
+Cuando subes este repositorio a **EasyPanel** y seleccionas la opción
+"Dockerfile", la imagen resultante utilizará el script `start.sh` para poner en
+marcha el servidor. Al arrancar el contenedor verás en los logs un mensaje con
+la URL de acceso. Por defecto podrás conectarte a
+`http://TU_IP_o_DOMINIO:12321` a menos que hayas modificado el puerto con la
+variable `SERVER_PORT`.
 
 ### Docker FAQ
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Simple helper to build the Kepler Docker image and run it with MariaDB without docker-compose
+
+set -e
+
+IMAGE_NAME=kepler
+DB_CONTAINER=kepler-db
+APP_CONTAINER=kepler
+
+# Build Kepler image
+
+docker build -t $IMAGE_NAME .
+
+# Start MariaDB container if not already running
+if [ ! "$(docker ps -q -f name=$DB_CONTAINER)" ]; then
+  if [ "$(docker ps -aq -f status=exited -f name=$DB_CONTAINER)" ]; then
+    docker rm $DB_CONTAINER
+  fi
+  docker run -d --name $DB_CONTAINER \
+    -e MARIADB_ROOT_PASSWORD=veryverysecret \
+    -e MYSQL_DATABASE=kepler \
+    -e MYSQL_USER=kepler \
+    -e MYSQL_PASSWORD=verysecret \
+    -v "$(pwd)/tools/kepler.sql:/docker-entrypoint-initdb.d/kepler.sql" \
+    mariadb:11.4
+fi
+
+# Start Kepler container, removing any old one
+if [ "$(docker ps -aq -f name=$APP_CONTAINER)" ]; then
+  docker rm -f $APP_CONTAINER
+fi
+
+docker run -d --name $APP_CONTAINER --link $DB_CONTAINER:mariadb \
+  -p 12321:12321 -p 12309:12309 -p 12322:12322 \
+  -e MYSQL_HOSTNAME=mariadb \
+  $IMAGE_NAME
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Startup script for EasyPanel and Docker
+
+# Print URL for connecting to the Kepler server
+HOST=${SERVER_HOST:-localhost}
+PORT=${SERVER_PORT:-12321}
+
+cat <<MSG
+Kepler se está iniciando...
+Podrás conectarte a tu hotel en: http://${HOST}:${PORT}
+MSG
+
+# Ejecutar script existente de arranque
+exec sh run.sh
+


### PR DESCRIPTION
## Summary
- mount `kepler.sql` in `deploy.sh` so MariaDB imports it automatically
- document DB import in the deploy script instructions

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68644ae72a80833292e1b513b3738dfe